### PR TITLE
Skip copying settings file during deployment to preserve local Pi set…

### DIFF
--- a/scripts/deploy_to_pi.sh
+++ b/scripts/deploy_to_pi.sh
@@ -28,7 +28,8 @@ scp picamctl.py ${PI_USER}@${PI_HOST}:${REMOTE_DIR}/
 scp templates/garage_cam_template.html ${PI_USER}@${PI_HOST}:${REMOTE_DIR}/
 scp templates/landing.html ${PI_USER}@${PI_HOST}:${REMOTE_DIR}/
 scp templates/vlc_stream.html ${PI_USER}@${PI_HOST}:${REMOTE_DIR}/
-scp picamctl_settings.json ${PI_USER}@${PI_HOST}:${REMOTE_DIR}/
+# Skip settings file - preserve local Pi settings
+# scp picamctl_settings.json ${PI_USER}@${PI_HOST}:${REMOTE_DIR}/
 scp systemd/picamctl.service ${PI_USER}@${PI_HOST}:${REMOTE_DIR}/
 scp scripts/manage_service.sh ${PI_USER}@${PI_HOST}:${REMOTE_DIR}/
 


### PR DESCRIPTION
Camera settings were being pushed from the development environment, overwriting saved camera settings on the device. The device settings are the source of truth.
