### PR TITLE
Improve VLC page: Add mobile device guidance and condense instructions

### DIFF
--- a/templates/vlc_stream.html
+++ b/templates/vlc_stream.html
@@ -364,7 +364,7 @@
                 <div class="step">
                     <span class="step-number">1</span>
                     <div class="step-content">
-                        <strong>Open VLC Media Player</strong><br>
+                        <strong>Open VLC Media Player</strong> (Desktop)<br>
                         Download from <a href="https://www.videolan.org/" target="_blank">videolan.org</a> if needed
                     </div>
                 </div>
@@ -372,8 +372,8 @@
                 <div class="step">
                     <span class="step-number">2</span>
                     <div class="step-content">
-                        <strong>Open Network Stream</strong><br>
-                        Go to <strong>Media → Open Network Stream</strong> (or press <kbd>Ctrl+N</kbd> / <kbd>Cmd+N</kbd>)
+                        <strong>Open Network Stream</strong> (<kbd>Ctrl+N</kbd> / <kbd>Cmd+N</kbd>)<br>
+                        Media → Open Network Stream
                     </div>
                 </div>
                 
@@ -381,26 +381,16 @@
                     <span class="step-number">3</span>
                     <div class="step-content">
                         <strong>Paste the Stream URL</strong><br>
-                        Click "Copy" above and paste the TCP URL into VLC's network stream field
-                    </div>
-                </div>
-                
-                <div class="step">
-                    <span class="step-number">4</span>
-                    <div class="step-content">
-                        <strong>Click Play</strong><br>
-                        The stream should start within 1-2 seconds with ~200-500ms latency
+                        Click "Copy" above and paste into VLC's network stream field
                     </div>
                 </div>
                 
                 <div class="note warning">
-                    <strong>⚠️ Important:</strong> The M3U playlist download below may not work with all media players. 
-                    For best results, <strong>manually copy the URL and paste it into VLC</strong> using Media → Open Network Stream.
+                    <strong>📱 Mobile Users:</strong> VLC streaming is optimized for desktop. On mobile devices, use the <a href="/web" style="color: #667eea; text-decoration: underline;">Web Interface</a> instead for best results.
                 </div>
                 
                 <div class="note">
-                    <strong>💡 Pro Tip:</strong> For even lower latency, go to VLC's Tools → Preferences → Show settings: All → 
-                    Input/Codecs and set "Network caching" to 100-300ms
+                    <strong>💡 Lower Latency:</strong> In VLC, set Tools → Preferences → Input/Codecs → Network caching to 100-300ms
                 </div>
             </div>
             


### PR DESCRIPTION
## Problem

VLC streaming doesn't work reliably on Android VLC app, but the VLC page had no indication that it's desktop-only. The instructions were also verbose and taking up too much screen space.

## Changes

**Condensed Instructions:**
- Reduced from 4 steps to 3 by consolidating related information
- Removed redundant M3U playlist warning
- Simplified latency optimization tip to single line

**Added Mobile Device Note:**
- Prominent warning box for mobile users directing them to the Web Interface
- Direct link to `/web` for easy navigation
- Clear message: "VLC streaming is optimized for desktop"

**Why VLC doesn't work on mobile:**
- Android/iOS VLC apps don't handle raw H.264 TCP streams well
- Desktop VLC has better codec/network protocol support
- The HLS-based Web Interface is purpose-built for mobile browsers

## UI Improvements

Before: 4 steps + 2 warning boxes (cluttered)
After: 3 steps + 2 concise notes (cleaner)

Net result: -10 lines, clearer messaging, better mobile UX

## Testing

- ✅ Desktop VLC still works (unchanged functionality)
- ✅ Mobile users see clear guidance to use Web Interface
- ✅ Page is less cluttered and easier to scan