### PR TITLE
Fix: Ensure service is enabled for autostart in deployment script

### DIFF
--- a/scripts/deploy_to_pi.sh
+++ b/scripts/deploy_to_pi.sh
@@ -73,9 +73,9 @@ fi
 echo "⚙️  Installing systemd service..."
 ssh ${PI_USER}@${PI_HOST} "sudo cp ${REMOTE_DIR}/picamctl.service /etc/systemd/system/ && sudo systemctl daemon-reload"
 
-# Restart service
-echo "🔄 Restarting picamctl service..."
-ssh ${PI_USER}@${PI_HOST} "sudo systemctl restart picamctl"
+# Enable and restart service
+echo "🔄 Enabling and restarting picamctl service..."
+ssh ${PI_USER}@${PI_HOST} "sudo systemctl enable picamctl && sudo systemctl restart picamctl"
 
 # Check status
 echo ""


### PR DESCRIPTION
## Problem

The deployment script was only **restarting** the picamctl service, not **enabling** it for autostart. This caused issues where:
- Service wouldn't start after deployment if it had been disabled
- Fresh installs wouldn't have the service enabled on boot
- After a Pi reboot, the service wouldn't start automatically

This is what happened with pizero2 - the service was deployed but not enabled, so it remained inactive.

## Solution

Added `sudo systemctl enable picamctl` before the restart command in the deployment script.

Now the script ensures:
- ✅ Service is enabled for autostart on boot
- ✅ Service starts immediately after deployment
- ✅ Consistent behavior across all deployments

## Changes

Modified `scripts/deploy_to_pi.sh`:
- Changed "Restarting" message to "Enabling and restarting"
- Added `enable` command before `restart`

## Testing

Verified on pizero2:
- Service is now enabled and running
- Confirmed with `systemctl is-enabled picamctl` → `enabled`