### PR TITLE
Improve dark room preset & preserve camera settings on reset

### DIFF
--- a/picamctl.py
+++ b/picamctl.py
@@ -2134,12 +2134,18 @@ def apply_settings():
 
 @app.route('/reset', methods=['POST'])
 def reset_settings():
-    """Reset all settings to defaults"""
+    """Reset all settings to defaults (preserves camera name and MQTT settings)"""
     global camera_running
+
+    # Preserve camera name and MQTT settings
+    preserved_camera_name = settings.get('camera_name', 'Garage Cam')
+    preserved_mqtt_enabled = settings.get('mqtt_enabled', False)
+    preserved_mqtt_broker = settings.get('mqtt_broker', '192.168.0.167')
+    preserved_mqtt_port = settings.get('mqtt_port', 1883)
+    preserved_mqtt_base_topic = settings.get('mqtt_base_topic', 'surveillance')
 
     # Reset to default settings
     default_settings = {
-        'camera_name': 'Garage Cam',
         'width': 1280,
         'height': 720,
         'framerate': 15,
@@ -2165,6 +2171,13 @@ def reset_settings():
 
     # Update runtime settings
     settings.update(default_settings)
+    
+    # Restore preserved settings
+    settings['camera_name'] = preserved_camera_name
+    settings['mqtt_enabled'] = preserved_mqtt_enabled
+    settings['mqtt_broker'] = preserved_mqtt_broker
+    settings['mqtt_port'] = preserved_mqtt_port
+    settings['mqtt_base_topic'] = preserved_mqtt_base_topic
 
     # Stop camera and reset flag
     stop_camera_process()

--- a/scripts/deploy_to_pi.sh
+++ b/scripts/deploy_to_pi.sh
@@ -38,7 +38,7 @@ scp requirements.txt ${PI_USER}@${PI_HOST}:${REMOTE_DIR}/
 
 # Install system dependencies (required for fresh installs)
 echo "📦 Installing system dependencies..."
-ssh ${PI_USER}@${PI_HOST} "sudo apt-get update -qq && sudo apt-get install -y -qq python3-pip python3-flask python3-paho-mqtt ffmpeg > /dev/null 2>&1" && echo "   System dependencies installed" || echo "   ⚠️  Some dependencies may have failed - check manually"
+ssh ${PI_USER}@${PI_HOST} "set -e; echo '   Running apt-get update...'; sudo apt-get update -qq; echo '   Installing system packages...'; sudo apt-get install -y -qq python3-pip python3-flask python3-paho-mqtt ffmpeg" && echo "   System dependencies installed" || echo "   ⚠️  Some dependencies may have failed - check the apt-get output above"
 
 # Install Python dependencies (for any extras not in apt)
 echo "📦 Installing Python dependencies..."

--- a/scripts/deploy_to_pi.sh
+++ b/scripts/deploy_to_pi.sh
@@ -36,7 +36,11 @@ scp systemd/picamctl.service ${PI_USER}@${PI_HOST}:${REMOTE_DIR}/
 scp scripts/manage_service.sh ${PI_USER}@${PI_HOST}:${REMOTE_DIR}/
 scp requirements.txt ${PI_USER}@${PI_HOST}:${REMOTE_DIR}/
 
-# Install Python dependencies
+# Install system dependencies (required for fresh installs)
+echo "📦 Installing system dependencies..."
+ssh ${PI_USER}@${PI_HOST} "sudo apt-get update -qq && sudo apt-get install -y -qq python3-pip python3-flask python3-paho-mqtt ffmpeg > /dev/null 2>&1" && echo "   System dependencies installed" || echo "   ⚠️  Some dependencies may have failed - check manually"
+
+# Install Python dependencies (for any extras not in apt)
 echo "📦 Installing Python dependencies..."
 ssh ${PI_USER}@${PI_HOST} << EOF
     cd ${REMOTE_DIR}

--- a/templates/garage_cam_template.html
+++ b/templates/garage_cam_template.html
@@ -1606,9 +1606,12 @@
         function applyDarkModePreset() {
             // Apply dark room optimized settings - send all at once
             const presetSettings = {
-                gain: 2.0,
-                shutter: 200000,  // 200ms in microseconds
-                contrast: 0.5
+                gain: 6.0,           // Maximum gain for low light
+                shutter: 800000,     // 800ms exposure for very dark rooms
+                contrast: 1.5,       // Boost contrast
+                brightness: 0.3,     // Increase brightness
+                ev: 2.0,             // Positive EV compensation
+                saturation: 0.5      // Slight saturation boost
             };
 
             fetch('/apply', {
@@ -1617,14 +1620,20 @@
                 body: JSON.stringify(presetSettings)
             }).then(() => {
                 // Update UI sliders
-                document.getElementById('gain').value = 2;
-                document.getElementById('shutter').value = 200;  // UI shows 0-1200 scale
-                document.getElementById('contrast').value = 0.5;
-                updateSlider('gain', 2);
-                updateSlider('shutter', 200);
-                updateSlider('contrast', 0.5);
+                document.getElementById('gain').value = 6;
+                document.getElementById('shutter').value = 800;  // UI shows 0-1200 scale
+                document.getElementById('contrast').value = 1.5;
+                document.getElementById('brightness').value = 0.3;
+                document.getElementById('ev').value = 2.0;
+                document.getElementById('saturation').value = 0.5;
+                updateSlider('gain', 6);
+                updateSlider('shutter', 800);
+                updateSlider('contrast', 1.5);
+                updateSlider('brightness', 0.3);
+                updateSlider('ev', 2.0);
+                updateSlider('saturation', 0.5);
 
-                showNotification('Dark Mode Preset Applied', 'success');
+                showNotification('Dark Room Preset Applied - Max Sensitivity', 'success');
             });
         }
 
@@ -1717,16 +1726,16 @@
         }
 
         function resetCameraSettings() {
-            if (confirm('Reset all camera settings to defaults? This will save defaults to disk and reload the page.')) {
+            if (confirm('Reset camera settings to defaults?\n\nThis will NOT reset:\n• Camera name\n• MQTT configuration\n\nSettings will be saved and the page will reload.')) {
                 fetch('/reset', {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'}
                 }).then(response => response.json()).then(data => {
-                    showNotification('Settings reset to defaults', 'success');
+                    showNotification('Camera settings reset (name & MQTT preserved)', 'success');
                     // Wait a moment before reloading to ensure settings are saved
                     setTimeout(() => {
                         location.reload();
-                    }, 1000);
+                    }, 1500);
                 }).catch(error => {
                     showNotification('Failed to reset settings', 'error');
                     console.error('Reset error:', error);


### PR DESCRIPTION
## Changes

### Dark Room Preset Improvements
The "Dark Mode Preset" button was too conservative for truly dark rooms, resulting in light gray/underexposed images. Updated with aggressive low-light settings:

- **Gain**: 6.0 (max) instead of 2.0
- **Exposure**: 800ms instead of 200ms 
- **Contrast**: 1.5 instead of 0.5
- **Brightness**: +0.3 (new)
- **EV Compensation**: +2.0 (new)
- **Saturation**: +0.5 (new)

### Reset Camera Settings Preservation
The "Reset Camera Settings" button now preserves important configuration that shouldn't be reset:

- **Camera name** - keeps custom device names
- **MQTT configuration** - preserves broker, port, base topic, and enabled state

Updated confirmation dialog to clearly explain what will and won't be reset.

## Testing
- [x] Deployed to pizero1 and pizero3
- [x] Dark room preset provides much brighter image in low light
- [x] Reset preserves camera name and MQTT settings

## Related Issues
Fixes underexposed camera feed in dark environments and prevents accidental loss of device configuration.